### PR TITLE
test(BE/): 9 input and 4 more path validation test cases

### DIFF
--- a/BE/README.md
+++ b/BE/README.md
@@ -182,7 +182,7 @@ uv sync        # installs all runtime and dev dependencies from uv.lock
 uv run pytest
 ```
 
-Expected: **22 passed**. The suite covers:
+Expected: **35 passed**. The suite covers:
 
 | Test class | What it verifies |
 | --- | --- |
@@ -190,7 +190,8 @@ Expected: **22 passed**. The suite covers:
 | `TestMultiGoal` | A\* visits **every** objective in a two-goal maze and ends at a goal |
 | `TestUnreachable` | A\* returns `[]` when the goal is walled off with no path |
 | `TestMaze` | `Maze` correctly parses start, objectives, dimensions, and neighbor counts; loading from a file and from a string give identical results |
-| `TestIsValidPath` | `isValidPath` correctly rejects: empty path, path through a wall, path that skips a goal, path that doesn't end at a goal, non-consecutive steps |
+| `TestIsValidPath` | `isValidPath` correctly rejects: empty path, path through a wall, path that skips a goal, path that doesn't end at a goal, non-consecutive steps, wrong argument types, and unnecessary revisits |
+| `TestMazeValidation` | `Maze(...)` raises `ValueError` for every invalid input: empty string, jagged rows, exceeding row/column limits, invalid characters, missing or duplicate start, missing objectives, and too many objectives |
 
 ### 3. Manual Smoke Test
 

--- a/BE/tests/test_sample.py
+++ b/BE/tests/test_sample.py
@@ -213,6 +213,22 @@ class TestIsValidPath:
         # Teleports from start directly to goal — Manhattan distance 8
         assert maze.isValidPath([(1, 1), (3, 7)]) != "Valid"
 
+    def test_path_not_a_list(self):
+        assert make_maze(SINGLE).isValidPath("not a list") != "Valid"
+
+    def test_path_position_not_tuple(self):
+        assert make_maze(SINGLE).isValidPath([1, 2]) != "Valid"
+
+    def test_path_position_wrong_length(self):
+        assert make_maze(SINGLE).isValidPath([(1,)]) != "Valid"
+
+    def test_path_with_unnecessary_revisit(self):
+        maze = make_maze(SINGLE)
+        # Revisits (1,2) with no objective collected between the two visits
+        path = [(1,2), (1,1), (1,2), (1,3), (1,4), (1,5), (1,6), (1,7), (2,7), (3,7)]
+        assert maze.isValidPath(path) != "Valid"
+
+
 # ── Maze constructor input validation ─────────────────────────────────────────
 
 class TestMazeValidation:

--- a/BE/tests/test_sample.py
+++ b/BE/tests/test_sample.py
@@ -212,3 +212,51 @@ class TestIsValidPath:
         maze = make_maze(SINGLE)
         # Teleports from start directly to goal — Manhattan distance 8
         assert maze.isValidPath([(1, 1), (3, 7)]) != "Valid"
+
+# ── Maze constructor input validation ─────────────────────────────────────────
+
+class TestMazeValidation:
+
+    def test_empty_input(self):
+        with pytest.raises(ValueError, match="empty"):
+            Maze("")
+
+    def test_jagged_rows(self):
+        with pytest.raises(ValueError, match="same length"):
+            Maze("#####\n#H.*##\n#####\n")
+
+    def test_too_many_rows(self):
+        # 101 rows: border + H-row + *-row + 98 more border rows
+        body = "###\n" + "#H#\n" + "#*#\n" + "###\n" * 98
+        with pytest.raises(ValueError, match="row limit"):
+            Maze(body)
+
+    def test_too_many_cols(self):
+        # 101-column maze — one column over MAX_COLS
+        wide = "#" * 101
+        inner = "#H" + "." * 97 + "*#"   # 2 + 97 + 2 = 101 chars
+        with pytest.raises(ValueError, match="column limit"):
+            Maze(f"{wide}\n{inner}\n{wide}\n")
+
+    def test_invalid_char(self):
+        with pytest.raises(ValueError, match="Invalid character"):
+            Maze("#####\n#HX*#\n#####\n")
+
+    def test_no_start(self):
+        with pytest.raises(ValueError, match="no start"):
+            Maze("#####\n#..*#\n#####\n")
+
+    def test_multiple_starts(self):
+        with pytest.raises(ValueError, match="start positions"):
+            Maze("#####\n#HH*#\n#####\n")
+
+    def test_no_objective(self):
+        with pytest.raises(ValueError, match="no objectives"):
+            Maze("#####\n#H..#\n#####\n")
+
+    def test_too_many_objectives(self):
+        # 11 objectives — one over MAX_OBJECTIVES (10)
+        inner = "#H" + "*" * 11 + "#"   # 14 chars
+        border = "#" * 14
+        with pytest.raises(ValueError, match="objective limit"):
+            Maze(f"{border}\n{inner}\n{border}\n")


### PR DESCRIPTION
This PR addresses issue #8 by adding 9 input validation test cases. It also adds 4 output-path validation test cases. Meanwhile, the relevant sections of `BE/README.md` have been updated.