### PR TITLE
feat(BE): enrich get_Astar_result yield with cost, remaining, and frontier snapshot

### DIFF
--- a/BE/README.md
+++ b/BE/README.md
@@ -67,7 +67,15 @@ gen = get_Astar_result(maze)
 
 `get_Astar_result` is a **Python generator**. It has two kinds of output:
 
-1. **`yield`** — emits each `(row, col)` position as A\* explores it (use this to animate the search)
+1. **`yield`** — emits a `dict` for each A\* expansion (use this to animate the search); keys:
+
+   | Key | Type | Description |
+   | --- | --- | --- |
+   | `"pos"` | `tuple[int, int]` | Grid cell just expanded |
+   | `"remaining"` | `frozenset[tuple[int, int]]` | Objectives not yet collected at this state |
+   | `"cost"` | `dict` | `{"g": int, "h": int}` — g-cost from start, h-cost (MST heuristic) |
+   | `"pq_top"` | `tuple[PqEntry, ...]` | Up to `PQ_SNAPSHOT_K` (5) cheapest live frontier entries, each `(f_cost, pos, remaining)` |
+
 2. **`return`** — the final shortest path as `list[(row, col)]`, retrieved via `StopIteration.value`
 
 #### Minimal usage (path only)
@@ -82,12 +90,12 @@ gen = get_Astar_result(maze)
 path = []
 try:
     while True:
-        next(gen)          # drive the generator with ignoring explored positions
+        next(gen)          # drive the generator, ignoring step data
 except StopIteration as e:
     path = e.value         # list[(row, col)]: the complete optimal path
 ```
 
-#### Full usage (explored positions + path + validation)
+#### Full usage (step data + path + validation)
 
 ```python
 from maze import Maze
@@ -96,17 +104,22 @@ from backend import get_Astar_result
 maze = Maze("maze.txt")
 gen = get_Astar_result(maze)
 
-# Step 1: stream explored positions for search animation
-explored = []
+steps = []
 path = []
 try:
     while True:
-        pos = next(gen)    # (row, col) of each node A* expands
-        explored.append(pos)
-except StopIteration as e:
-    path = e.value         # list[(row, col)]: the complete optimal path
+        step = next(gen)
+        steps.append(step)
 
-# Step 2: validate — determines how the frontend should render the result
+        pos       = step["pos"]            # (row, col) of the cell just expanded
+        remaining = step["remaining"]      # frozenset of objectives not yet collected
+        g         = step["cost"]["g"]      # cost from start to this cell
+        h         = step["cost"]["h"]      # MST heuristic estimate to collect remaining
+        pq_top    = step["pq_top"]         # up to 5 cheapest frontier candidates
+except StopIteration as e:
+    path = e.value                         # list[(row, col)]: the complete optimal path
+
+# Validate before committing to a success render
 result = maze.isValidPath(path)
 if result == "Valid":
     pass  # render success state
@@ -125,7 +138,7 @@ Expected flow:
 
 | Variable | Type | Description |
 | --- | --- | --- |
-| `pos` | `tuple[int, int]` | A grid cell explored during search — for visualizing the search frontier |
+| `step` | `dict` | One dict per A\* expansion — see key table above |
 | `path` | `list[tuple[int, int]]` | Ordered positions from start to the last objective; `[]` if the goal is unreachable |
 | `result` | `str` | `"Valid"` on success; a violation description string otherwise |
 
@@ -182,7 +195,7 @@ uv sync        # installs all runtime and dev dependencies from uv.lock
 uv run pytest
 ```
 
-Expected: **35 passed**. The suite covers:
+Expected: **44 passed**. The suite covers:
 
 | Test class | What it verifies |
 | --- | --- |
@@ -192,6 +205,7 @@ Expected: **35 passed**. The suite covers:
 | `TestMaze` | `Maze` correctly parses start, objectives, dimensions, and neighbor counts; loading from a file and from a string give identical results |
 | `TestIsValidPath` | `isValidPath` correctly rejects: empty path, path through a wall, path that skips a goal, path that doesn't end at a goal, non-consecutive steps, wrong argument types, and unnecessary revisits |
 | `TestMazeValidation` | `Maze(...)` raises `ValueError` for every invalid input: empty string, jagged rows, exceeding row/column limits, invalid characters, missing or duplicate start, missing objectives, and too many objectives |
+| `TestYieldFormat` | Each yielded step is a dict with the correct keys and types; `cost` g/h are non-negative; `pq_top` entries are valid `PqEntry` tuples bounded by `PQ_SNAPSHOT_K`; terminal step has empty `remaining` and `h == 0` |
 
 ### 3. Manual Smoke Test
 
@@ -221,14 +235,14 @@ from backend import get_Astar_result
 
 maze = Maze("your_maze.txt")
 gen = get_Astar_result(maze)
-explored, path = [], []
+steps, path = [], []
 try:
     while True:
-        explored.append(next(gen))
+        steps.append(next(gen))
 except StopIteration as e:
     path = e.value
 
-print("Explored:", len(explored), "states")
+print("Explored:", len(steps), "states")
 print("Path:", path)
 print("Valid?", maze.isValidPath(path))
 ```

--- a/BE/README.md
+++ b/BE/README.md
@@ -73,6 +73,7 @@ gen = get_Astar_result(maze)
    | --- | --- | --- |
    | `"pos"` | `tuple[int, int]` | Grid cell just expanded |
    | `"remaining"` | `frozenset[tuple[int, int]]` | Objectives not yet collected at this state |
+   | `"color"` | `int` | Stable index in `1..2**N` (where `N = len(objectives)`) — bitmask over the sorted original objectives, `+1`. With `MAX_OBJECTIVES = 3` this is exactly `1..8`. `1` = all collected (terminal); `2**N` = none collected (start). Use as a layer/color id in the frontend. |
    | `"cost"` | `dict` | `{"g": int, "h": int}` — g-cost from start, h-cost (MST heuristic) |
    | `"pq_top"` | `tuple[PqEntry, ...]` | Up to `PQ_SNAPSHOT_K` (5) cheapest live frontier entries, each `(f_cost, pos, remaining)` |
 
@@ -195,7 +196,7 @@ uv sync        # installs all runtime and dev dependencies from uv.lock
 uv run pytest
 ```
 
-Expected: **44 passed**. The suite covers:
+Expected: **68 passed**. The suite covers:
 
 | Test class | What it verifies |
 | --- | --- |
@@ -206,6 +207,11 @@ Expected: **44 passed**. The suite covers:
 | `TestIsValidPath` | `isValidPath` correctly rejects: empty path, path through a wall, path that skips a goal, path that doesn't end at a goal, non-consecutive steps, wrong argument types, and unnecessary revisits |
 | `TestMazeValidation` | `Maze(...)` raises `ValueError` for every invalid input: empty string, jagged rows, exceeding row/column limits, invalid characters, missing or duplicate start, missing objectives, and too many objectives |
 | `TestYieldFormat` | Each yielded step is a dict with the correct keys and types; `cost` g/h are non-negative; `pq_top` entries are valid `PqEntry` tuples bounded by `PQ_SNAPSHOT_K`; terminal step has empty `remaining` and `h == 0` |
+| `TestYieldCosts` | Initial step has `g == 0` and `pos == start`; initial `h` equals `mst_heuristic(start, all_objectives)`; terminal `g` equals returned path length; cached `h` matches a fresh `mst_heuristic` call for every step; step count equals `Maze.getStatesExplored()` |
+| `TestPqTop` | `pq_top` entries are sorted by `f_cost` ascending; never re-list the just-expanded state; terminal step never re-lists itself |
+| `TestUnreachableYield` | Unreachable mazes still yield ≥ 1 step before returning; no yielded step on an unreachable maze has empty `remaining`; the generator's return value is `[]` |
+| `TestRemainingColorIndex` | `remaining_color_index` is a stable bitmask-based hash: empty → `1`, full → `2**N`, distinct subsets → distinct indices, value bounded by `1..8` for 3 objectives, deterministic across calls |
+| `TestYieldColor` | Each step's `color` matches the helper run over the maze's original objectives; first step has `color == 2**N`; terminal step has `color == 1`; value stays in `1..8`; same `remaining` → same `color`; sequence is non-increasing along the run |
 
 ### 3. Manual Smoke Test
 

--- a/BE/backend.py
+++ b/BE/backend.py
@@ -62,9 +62,9 @@ def get_Astar_result(
       - "pos": the grid cell just expanded (Pos)
       - "remaining": frozenset of objectives not yet collected at this state
       - "cost": {"g": g_cost, "h": h_cost} for the expanded node
-      - "pq_top": up to PQ_SNAPSHOT_K cheapest live (non-visited) PQ entries,
-                  each as (f_cost, pos, remaining); neighbours are pushed first
-                  so this reflects the immediate future frontier
+      - "pq_top": up to PQ_SNAPSHOT_K cheapest live (non-visited) states,
+                  each as (f_cost, pos, remaining); the same cell may appear
+                  multiple times with different remaining sets (different layers)
 
     Returns the path (first step after start → last objective) via StopIteration.value.
     The start position itself is excluded from the returned path.
@@ -116,17 +116,12 @@ def get_Astar_result(
                     heapq.heappush(priority_queue, (priority, new_state))
                     parents[new_state] = state
 
-        # Snapshot top-K live (non-visited, pos-deduplicated) entries from the heap.
+        # Snapshot top-K live (non-visited) states from the heap.
         pq_top: list[PqEntry] = []
-        seen_pos: set[Pos] = set()
         for f, cand_state in heapq.nsmallest(PQ_SNAPSHOT_K * 4, priority_queue):
             if cand_state in visited:
                 continue
-            cand_pos = cand_state[0]
-            if cand_pos in seen_pos:
-                continue
-            pq_top.append((f, cand_pos, cand_state[1]))
-            seen_pos.add(cand_pos)
+            pq_top.append((f, cand_state[0], cand_state[1]))
             if len(pq_top) >= PQ_SNAPSHOT_K:
                 break
 

--- a/BE/backend.py
+++ b/BE/backend.py
@@ -5,6 +5,10 @@ from maze import Maze
 
 type Pos = tuple[int, int] # (row, col)
 type State = tuple[Pos, frozenset[Pos]] # (current position, remaining objectives)
+type PqEntry = tuple[int, Pos, frozenset[Pos]] # (f_cost, position, remaining)
+
+# Number of top priority-queue entries to expose per step for visualization.
+PQ_SNAPSHOT_K = 5
 
 
 def manhattan(a: Pos, b: Pos) -> int:

--- a/BE/backend.py
+++ b/BE/backend.py
@@ -131,10 +131,11 @@ def get_Astar_result(
                 break
 
         g = g_cost[state]
+        h = mst_heuristic(pos, remaining)
         yield {
             "pos": pos, # the cell just expanded
             "remaining": remaining, # objectives not yet collected at this state
-            "cost": {"g": g, "h": f_priority - g}, # separate g and h for visualization
+            "cost": {"g": g, "h": h}, # separate g and h for visualization
             "pq_top": tuple(pq_top), # up to PQ_SNAPSHOT_K cheapest live (non-visited) PQ entries, each as (f_cost, pos, remaining)
         }
 

--- a/BE/backend.py
+++ b/BE/backend.py
@@ -48,7 +48,9 @@ def mst_heuristic(pos: Pos, remaining: frozenset[Pos]) -> int:
     return total
 
 
-def get_Astar_result(maze: Maze) -> Generator[Pos, None, list[Pos]]:
+def get_Astar_result(
+    maze: Maze,
+) -> Generator[dict, None, list[Pos]]:
     """
     Multi-objective A* search over the maze.
 
@@ -56,8 +58,15 @@ def get_Astar_result(maze: Maze) -> Generator[Pos, None, list[Pos]]:
     so revisiting a cell with a different remaining set is treated as a distinct state —
     necessary for correctness when objectives can be collected in any order.
 
-    Yields each explored position for visualization. Returns the path
-    (first step after start → ... → last objective) via StopIteration.value.
+    Per expansion, yields a dict with keys:
+      - "pos": the grid cell just expanded (Pos)
+      - "remaining": frozenset of objectives not yet collected at this state
+      - "cost": {"g": g_cost, "h": h_cost} for the expanded node
+      - "pq_top": up to PQ_SNAPSHOT_K cheapest live (non-visited) PQ entries,
+                  each as (f_cost, pos, remaining); neighbours are pushed first
+                  so this reflects the immediate future frontier
+
+    Returns the path (first step after start → last objective) via StopIteration.value.
     The start position itself is excluded from the returned path.
     """
     # Initialize the priority queue with the starting position and all objectives remaining
@@ -82,7 +91,7 @@ def get_Astar_result(maze: Maze) -> Generator[Pos, None, list[Pos]]:
     # We loop until there are no more states to explore (i.e. the priority queue is empty)
     while priority_queue:
         # Pop the state with the lowest f_cost (g_cost + heuristic) from the priority queue
-        _, state = heapq.heappop(priority_queue)
+        f_priority, state = heapq.heappop(priority_queue)
 
         # Skip stale heap entries: if we already expanded this state via a cheaper path, ignore it
         if state in visited:
@@ -91,32 +100,53 @@ def get_Astar_result(maze: Maze) -> Generator[Pos, None, list[Pos]]:
 
         pos, remaining = state
         maze._incrementStatesExplored()
-        yield pos
 
-        # If there are no remaining objectives, we have found a path to collect them all
-        if not remaining:
+        is_terminal = not remaining
+
+        # Expand neighbours before snapshotting so pq_top reflects the immediate future frontier.
+        if not is_terminal:
+            for n in maze.getNeighbors(pos[0], pos[1]):
+                new_remaining: frozenset[Pos] = remaining - {n}
+                new_state: State = (n, new_remaining)
+                new_cost: int = g_cost[state] + 1
+
+                if new_state not in g_cost or new_cost < g_cost[new_state]:
+                    g_cost[new_state] = new_cost
+                    priority: int = new_cost + mst_heuristic(n, new_remaining)
+                    heapq.heappush(priority_queue, (priority, new_state))
+                    parents[new_state] = state
+
+        # Snapshot top-K live (non-visited, pos-deduplicated) entries from the heap.
+        pq_top: list[PqEntry] = []
+        seen_pos: set[Pos] = set()
+        for f, cand_state in heapq.nsmallest(PQ_SNAPSHOT_K * 4, priority_queue):
+            if cand_state in visited:
+                continue
+            cand_pos = cand_state[0]
+            if cand_pos in seen_pos:
+                continue
+            pq_top.append((f, cand_pos, cand_state[1]))
+            seen_pos.add(cand_pos)
+            if len(pq_top) >= PQ_SNAPSHOT_K:
+                break
+
+        g = g_cost[state]
+        yield {
+            "pos": pos, # the cell just expanded
+            "remaining": remaining, # objectives not yet collected at this state
+            "cost": {"g": g, "h": f_priority - g}, # separate g and h for visualization
+            "pq_top": tuple(pq_top), # up to PQ_SNAPSHOT_K cheapest live (non-visited) PQ entries, each as (f_cost, pos, remaining)
+        }
+
+        if is_terminal:
             path: list[Pos] = []
             s: State | None = state
-            while s is not None: # reconstruct the path by following the parent pointers back to the start
+            while s is not None:
                 path.append(s[0])
                 s = parents[s]
             path.pop()
-            path.reverse() # reverse the path to get it from start to goal
+            path.reverse()
             return path
-
-        # For each valid neighboring position,
-        for n in maze.getNeighbors(pos[0], pos[1]):
-            new_remaining: frozenset[Pos] = remaining - {n} # if n is an objective, remove it from the remaining set
-            new_state: State = (n, new_remaining) # the new state is the neighbor position and the updated remaining objectives
-            new_cost: int = g_cost[state] + 1 # the cost to move to a neighbor is always 1
-
-            # A* logic: if we haven't seen this state before, or we found a cheaper path to it,
-            # update the costs and add it to the priority queue
-            if new_state not in g_cost or new_cost < g_cost[new_state]:
-                g_cost[new_state] = new_cost
-                priority: int = new_cost + mst_heuristic(n, new_remaining) # f_cost = g_cost + heuristic
-                heapq.heappush(priority_queue, (priority, new_state)) # push the new state with its f_cost into the priority queue
-                parents[new_state] = state # update the parent pointer for path reconstruction
 
     # No solution exists that collects all objectives.
     return []

--- a/BE/backend.py
+++ b/BE/backend.py
@@ -15,6 +15,24 @@ def manhattan(a: Pos, b: Pos) -> int:
     return abs(a[0] - b[0]) + abs(a[1] - b[1])
 
 
+def remaining_color_index(remaining: frozenset[Pos], objectives: tuple[Pos, ...]) -> int:
+    """
+    Map `remaining` to a stable color index in 1..2**len(objectives).
+
+    Each original objective is assigned a bit by its index in the sorted `objectives` tuple.
+    A bit is set iff that objective is still in `remaining`. Returns bitmask + 1.
+
+    With MAX_OBJECTIVES = 3 the range is exactly 1..8:
+      - all 3 still uncollected → 0b111 + 1 = 8
+      - all collected (terminal step) → 0b000 + 1 = 1
+    """
+    bits = 0
+    for i, obj in enumerate(objectives):
+        if obj in remaining:
+            bits |= 1 << i
+    return bits + 1
+
+
 def mst_heuristic(pos: Pos, remaining: frozenset[Pos]) -> int:
     """
     Lower-bound cost to connect pos to all remaining objectives via Prim's MST.
@@ -61,6 +79,8 @@ def get_Astar_result(
     Per expansion, yields a dict with keys:
       - "pos": the grid cell just expanded (Pos)
       - "remaining": frozenset of objectives not yet collected at this state
+      - "color": stable index in 1..2**len(objectives) for the remaining set —
+                 use as a layer/color identifier in the frontend (see remaining_color_index)
       - "cost": {"g": g_cost, "h": h_cost} for the expanded node
       - "pq_top": up to PQ_SNAPSHOT_K cheapest live (non-visited) states,
                   each as (f_cost, pos, remaining); the same cell may appear
@@ -79,12 +99,17 @@ def get_Astar_result(
         raise ValueError("Maze is missing objectives.")
 
     initial_remaining: frozenset[Pos] = frozenset(objectives)
+    # Stable, sorted snapshot of the original objective set — used as the bit-index basis for color hashing.
+    objectives_snapshot: tuple[Pos, ...] = tuple(sorted(initial_remaining))
     initial_state: State = (start, initial_remaining)
+    initial_h: int = mst_heuristic(start, initial_remaining)
     priority_queue: list[tuple[int, State]] = []
-    heapq.heappush(priority_queue, (0, initial_state))
+    heapq.heappush(priority_queue, (initial_h, initial_state))
 
     parents: dict[State, State | None] = {initial_state: None} # to reconstruct the path once we reach the goal
     g_cost: dict[State, int] = {initial_state: 0} # cost from start to this state
+    # h depends only on (pos, remaining), so it is invariant under cheaper-g updates — safe to cache once per state.
+    h_cost: dict[State, int] = {initial_state: initial_h}
     visited: set[State] = set() # states already expanded; skip stale heap entries
 
     # Main A* loop
@@ -112,7 +137,9 @@ def get_Astar_result(
 
                 if new_state not in g_cost or new_cost < g_cost[new_state]:
                     g_cost[new_state] = new_cost
-                    priority: int = new_cost + mst_heuristic(n, new_remaining)
+                    if new_state not in h_cost:
+                        h_cost[new_state] = mst_heuristic(n, new_remaining)
+                    priority: int = new_cost + h_cost[new_state]
                     heapq.heappush(priority_queue, (priority, new_state))
                     parents[new_state] = state
 
@@ -126,10 +153,11 @@ def get_Astar_result(
                 break
 
         g = g_cost[state]
-        h = mst_heuristic(pos, remaining)
+        h = h_cost[state]
         yield {
             "pos": pos, # the cell just expanded
             "remaining": remaining, # objectives not yet collected at this state
+            "color": remaining_color_index(remaining, objectives_snapshot), # stable 1..2**N index for FE coloring
             "cost": {"g": g, "h": h}, # separate g and h for visualization
             "pq_top": tuple(pq_top), # up to PQ_SNAPSHOT_K cheapest live (non-visited) PQ entries, each as (f_cost, pos, remaining)
         }

--- a/BE/maze.py
+++ b/BE/maze.py
@@ -21,7 +21,7 @@ type Pos = tuple[int, int]
 
 MAX_ROWS = 100
 MAX_COLS = 100
-MAX_OBJECTIVES = 10
+MAX_OBJECTIVES = 3
 _VALID_CHARS = frozenset('#.H*')
 
 

--- a/BE/tests/test_sample.py
+++ b/BE/tests/test_sample.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from backend import get_Astar_result
+from backend import get_Astar_result, mst_heuristic, remaining_color_index
 from maze import Maze
 import pytest
 
@@ -303,7 +303,7 @@ class TestYieldFormat:
     def test_dict_keys(self):
         steps = collect_steps(make_maze(SINGLE))
         for s in steps:
-            assert set(s.keys()) == {"pos", "remaining", "cost", "pq_top"}
+            assert set(s.keys()) == {"pos", "remaining", "color", "cost", "pq_top"}
 
     def test_pos_is_two_int_tuple(self):
         steps = collect_steps(make_maze(SINGLE))
@@ -351,3 +351,206 @@ class TestYieldFormat:
         steps = collect_steps(make_maze(MULTI_GOAL))
         sizes = [len(s["remaining"]) for s in steps]
         assert sizes == sorted(sizes, reverse=True)
+
+
+# ── Yield semantics: g/h correctness ──────────────────────────────────────────
+
+class TestYieldCosts:
+
+    def test_initial_step_g_zero(self):
+        """First yielded step is the start state — g must be 0."""
+        steps = collect_steps(make_maze(SINGLE))
+        assert steps[0]["cost"]["g"] == 0
+
+    def test_initial_step_pos_is_start(self):
+        """First yielded step's pos must equal maze start."""
+        maze = make_maze(SINGLE)
+        steps = collect_steps(maze)
+        assert steps[0]["pos"] == maze.getStart()
+
+    def test_initial_step_h_matches_mst(self):
+        """First yielded step's h must equal mst_heuristic(start, all_objectives)."""
+        maze = make_maze(MULTI_GOAL)
+        steps = collect_steps(maze)
+        expected_h = mst_heuristic(maze.getStart(), frozenset(maze.getObjectives()))
+        assert steps[0]["cost"]["h"] == expected_h
+
+    def test_terminal_g_equals_path_length(self):
+        """Terminal step's g (steps from start) must equal returned path length."""
+        for fixture in (SINGLE, MULTI, MULTI_GOAL):
+            maze = make_maze(fixture)
+            gen = get_Astar_result(maze)
+            last_step = None
+            try:
+                while True:
+                    last_step = next(gen)
+            except StopIteration as e:
+                path = e.value
+            assert last_step is not None
+            assert last_step["cost"]["g"] == len(path), \
+                f"Fixture {fixture!r}: terminal g={last_step['cost']['g']} but path len={len(path)}"
+
+    def test_cost_h_matches_mst_heuristic_each_step(self):
+        """Cached h must equal a fresh mst_heuristic call for every yielded state."""
+        for fixture in (SINGLE, MULTI, MULTI_GOAL):
+            steps = collect_steps(make_maze(fixture))
+            for s in steps:
+                expected = mst_heuristic(s["pos"], s["remaining"])
+                assert s["cost"]["h"] == expected, \
+                    f"h mismatch at pos={s['pos']} remaining={s['remaining']}: cached={s['cost']['h']} fresh={expected}"
+
+    def test_step_count_equals_states_explored(self):
+        """One yield per A* expansion: step count must equal Maze.getStatesExplored()."""
+        maze = make_maze(SINGLE)
+        steps = collect_steps(maze)
+        assert len(steps) == maze.getStatesExplored()
+
+
+# ── Yield semantics: pq_top ──────────────────────────────────────────────────
+
+class TestPqTop:
+
+    def test_pq_top_sorted_by_f_ascending(self):
+        """pq_top entries must be ordered by f_cost ascending."""
+        for fixture in (SINGLE, MULTI, MULTI_GOAL):
+            steps = collect_steps(make_maze(fixture))
+            for s in steps:
+                f_values = [entry[0] for entry in s["pq_top"]]
+                assert f_values == sorted(f_values), \
+                    f"pq_top not sorted at pos={s['pos']}: f_values={f_values}"
+
+    def test_pq_top_entries_not_in_visited(self):
+        """pq_top must never re-list the just-expanded state itself."""
+        steps = collect_steps(make_maze(MULTI_GOAL))
+        for s in steps:
+            current_state = (s["pos"], s["remaining"])
+            for _f, p, rem in s["pq_top"]:
+                assert (p, rem) != current_state, \
+                    f"pq_top re-lists just-expanded state {current_state}"
+
+    def test_pq_top_empty_on_terminal_step(self):
+        """Terminal step expands no neighbors and has no live frontier left for the goal layer.
+        The heap may still contain unexplored layers; allow ≤ K, but the cell just expanded
+        (with remaining=∅) must not reappear."""
+        steps = collect_steps(make_maze(SINGLE))
+        last = steps[-1]
+        for _f, p, rem in last["pq_top"]:
+            assert not (p == last["pos"] and rem == last["remaining"])
+
+
+# ── Yield semantics: unreachable ──────────────────────────────────────────────
+
+class TestUnreachableYield:
+
+    def test_unreachable_yields_at_least_start(self):
+        """Unreachable maze must still yield the start expansion before returning []."""
+        steps = collect_steps(make_maze(UNREACHABLE))
+        assert len(steps) >= 1
+
+    def test_unreachable_no_terminal_step(self):
+        """No yielded step on an unreachable maze should have empty remaining."""
+        steps = collect_steps(make_maze(UNREACHABLE))
+        for s in steps:
+            assert s["remaining"] != frozenset(), \
+                "Unreachable maze yielded a terminal (remaining=∅) step"
+
+    def test_unreachable_returns_empty_path(self):
+        """Sanity: generator return value on unreachable is []."""
+        gen = get_Astar_result(make_maze(UNREACHABLE))
+        try:
+            while True:
+                next(gen)
+        except StopIteration as e:
+            assert e.value == []
+
+
+# ── Color index for remaining ─────────────────────────────────────────────────
+
+class TestRemainingColorIndex:
+    """Direct tests of the helper. Bitmask + 1 over a sorted objective tuple."""
+
+    def test_empty_remaining_is_one(self):
+        objs = ((1, 1), (2, 2), (3, 3))
+        assert remaining_color_index(frozenset(), objs) == 1
+
+    def test_all_remaining_is_full_bitmask(self):
+        objs = ((1, 1), (2, 2), (3, 3))
+        # All three set: 0b111 + 1 = 8
+        assert remaining_color_index(frozenset(objs), objs) == 8
+
+    def test_single_bit_set(self):
+        objs = ((1, 1), (2, 2), (3, 3))
+        # Only the second objective remaining → 0b010 + 1 = 3
+        assert remaining_color_index(frozenset({(2, 2)}), objs) == 3
+
+    def test_distinct_subsets_distinct_indices(self):
+        """All 2**N subsets must produce distinct indices."""
+        objs = ((0, 0), (0, 1), (0, 2))
+        seen = set()
+        # Iterate every subset via the bitmask itself
+        for mask in range(1 << len(objs)):
+            subset = frozenset(o for i, o in enumerate(objs) if mask & (1 << i))
+            seen.add(remaining_color_index(subset, objs))
+        assert seen == set(range(1, 1 << len(objs) | 1))  # {1..8}
+
+    def test_range_bounded_1_to_8_for_3_objectives(self):
+        objs = ((0, 0), (1, 1), (2, 2))
+        for mask in range(1 << len(objs)):
+            subset = frozenset(o for i, o in enumerate(objs) if mask & (1 << i))
+            c = remaining_color_index(subset, objs)
+            assert 1 <= c <= 8
+
+    def test_stable_across_calls(self):
+        objs = ((0, 0), (1, 1), (2, 2))
+        s = frozenset({(0, 0), (2, 2)})
+        assert remaining_color_index(s, objs) == remaining_color_index(s, objs)
+
+
+# ── Color in yielded steps ────────────────────────────────────────────────────
+
+class TestYieldColor:
+
+    def test_initial_step_color_is_full_bitmask(self):
+        """First yield has all objectives remaining → color = 2**N."""
+        maze = make_maze(MULTI_GOAL)
+        steps = collect_steps(maze)
+        n_obj = len(maze.getObjectives())
+        assert steps[0]["color"] == (1 << n_obj)
+
+    def test_terminal_step_color_is_one(self):
+        """Last yield has empty remaining → color = 1."""
+        for fixture in (SINGLE, MULTI, MULTI_GOAL):
+            steps = collect_steps(make_maze(fixture))
+            assert steps[-1]["color"] == 1
+
+    def test_color_in_range_1_to_8(self):
+        """With MAX_OBJECTIVES = 3, color must always fall in 1..8."""
+        for fixture in (SINGLE, MULTI, MULTI_GOAL):
+            steps = collect_steps(make_maze(fixture))
+            for s in steps:
+                assert 1 <= s["color"] <= 8
+
+    def test_color_matches_helper(self):
+        """Yielded color must equal remaining_color_index over the maze's original objectives."""
+        for fixture in (SINGLE, MULTI, MULTI_GOAL):
+            maze = make_maze(fixture)
+            objs = tuple(sorted(maze.getObjectives()))
+            for s in collect_steps(maze):
+                assert s["color"] == remaining_color_index(s["remaining"], objs)
+
+    def test_same_remaining_same_color_across_steps(self):
+        """Two yields with the same remaining must share the same color."""
+        steps = collect_steps(make_maze(MULTI_GOAL))
+        by_remaining: dict[frozenset, int] = {}
+        for s in steps:
+            r = s["remaining"]
+            if r in by_remaining:
+                assert by_remaining[r] == s["color"]
+            else:
+                by_remaining[r] = s["color"]
+
+    def test_color_nonincreasing_along_run(self):
+        """color = bitmask(remaining)+1, and remaining shrinks monotonically — color must be non-increasing."""
+        steps = collect_steps(make_maze(MULTI_GOAL))
+        colors = [s["color"] for s in steps]
+        assert colors == sorted(colors, reverse=True)

--- a/BE/tests/test_sample.py
+++ b/BE/tests/test_sample.py
@@ -81,6 +81,18 @@ def get_astar_path(maze):
         return e.value
 
 
+def collect_steps(maze):
+    """Collect all yielded dicts from the A* generator (discards final path)."""
+    gen = get_Astar_result(maze)
+    steps = []
+    try:
+        while True:
+            steps.append(next(gen))
+    except StopIteration:
+        pass
+    return steps
+
+
 # ── Single-goal correctness ───────────────────────────────────────────────────
 
 class TestPathfinding:
@@ -276,3 +288,66 @@ class TestMazeValidation:
         border = "#" * 7
         with pytest.raises(ValueError, match="objective limit"):
             Maze(f"{border}\n{inner}\n{border}\n")
+
+
+# ── Yield format ──────────────────────────────────────────────────────────────
+
+from backend import PQ_SNAPSHOT_K
+
+class TestYieldFormat:
+
+    def test_each_step_is_dict(self):
+        steps = collect_steps(make_maze(SINGLE))
+        assert all(isinstance(s, dict) for s in steps)
+
+    def test_dict_keys(self):
+        steps = collect_steps(make_maze(SINGLE))
+        for s in steps:
+            assert set(s.keys()) == {"pos", "remaining", "cost", "pq_top"}
+
+    def test_pos_is_two_int_tuple(self):
+        steps = collect_steps(make_maze(SINGLE))
+        for s in steps:
+            pos = s["pos"]
+            assert isinstance(pos, tuple) and len(pos) == 2
+            assert all(isinstance(x, int) for x in pos)
+
+    def test_remaining_is_frozenset(self):
+        steps = collect_steps(make_maze(SINGLE))
+        for s in steps:
+            assert isinstance(s["remaining"], frozenset)
+
+    def test_cost_keys_and_nonnegative(self):
+        steps = collect_steps(make_maze(SINGLE))
+        for s in steps:
+            cost = s["cost"]
+            assert set(cost.keys()) == {"g", "h"}
+            assert cost["g"] >= 0
+            assert cost["h"] >= 0
+
+    def test_pq_top_is_tuple_of_entries(self):
+        """Each pq_top entry must be (int, 2-tuple, frozenset)."""
+        steps = collect_steps(make_maze(SINGLE))
+        for s in steps:
+            assert isinstance(s["pq_top"], tuple)
+            for f, pos, rem in s["pq_top"]:
+                assert isinstance(f, int)
+                assert isinstance(pos, tuple) and len(pos) == 2
+                assert isinstance(rem, frozenset)
+
+    def test_pq_top_length_bounded(self):
+        steps = collect_steps(make_maze(SINGLE))
+        assert all(len(s["pq_top"]) <= PQ_SNAPSHOT_K for s in steps)
+
+    def test_terminal_step_remaining_empty_and_h_zero(self):
+        """The last yielded step must have empty remaining and h == 0."""
+        steps = collect_steps(make_maze(SINGLE))
+        last = steps[-1]
+        assert last["remaining"] == frozenset()
+        assert last["cost"]["h"] == 0
+
+    def test_multi_goal_remaining_shrinks_monotonically(self):
+        """Across a two-goal maze, len(remaining) never increases between steps."""
+        steps = collect_steps(make_maze(MULTI_GOAL))
+        sizes = [len(s["remaining"]) for s in steps]
+        assert sizes == sorted(sizes, reverse=True)

--- a/BE/tests/test_sample.py
+++ b/BE/tests/test_sample.py
@@ -271,8 +271,8 @@ class TestMazeValidation:
             Maze("#####\n#H..#\n#####\n")
 
     def test_too_many_objectives(self):
-        # 11 objectives — one over MAX_OBJECTIVES (10)
-        inner = "#H" + "*" * 11 + "#"   # 14 chars
-        border = "#" * 14
+        # 4 objectives — one over MAX_OBJECTIVES (3)
+        inner = "#H" + "*" * 4 + "#"   # 7 chars
+        border = "#" * 7
         with pytest.raises(ValueError, match="objective limit"):
             Maze(f"{border}\n{inner}\n{border}\n")


### PR DESCRIPTION
## Summary

  Implements Issue #20: enrich the `get_Astar_result` generator so the
  frontend can animate not just which cell was expanded, but *why* —
  showing g/h costs and the upcoming frontier candidates.

  **Changed files:**
  - `BE/backend.py` — new yield format, `PqEntry` type alias, `PQ_SNAPSHOT_K` constant
  - `BE/maze.py` — `MAX_OBJECTIVES`: 10 → 3 (matches the agreed 3-snack board)
  - `BE/tests/test_sample.py` — 9 new tests in `TestYieldFormat`; updated `test_too_many_objectives`
  - `BE/README.md` — updated interface docs and test count (35 → 44)
  ---

  ## New yield format

  `get_Astar_result(maze)` now yields a `dict` per expansion instead of a bare position:

  ```python
{
    "pos":       (row, col),           # cell just expanded
    "remaining": frozenset({...}),     # objectives not yet collected at this state
    "cost":      {"g": int, "h": int}, # g = cost from start, h = MST heuristic
    "color": int, # color index, rage [1, 8]
    "pq_top":    (                     # up to 5 cheapest live frontier entries
        (f_cost, (row, col), frozenset({...})),
        ...
    ),
}
```

`StopIteration.value` is still `list[tuple[int, int]]` — the final path, unchanged.

  ---

  How FE should call this (migration guide)

  Before:

```python
pos = next(gen)           # (row, col)
explored.append(pos)
```

  After:
```python
step = next(gen)
pos       = step["pos"]        # (row, col) — same as before
color   = step["color"] 
remaining = step["remaining"]  # frozenset — use as color-legend key
g, h      = step["cost"]["g"], step["cost"]["h"]
pq_top    = step["pq_top"]     # tuple of (f, pos, remaining)
```

  StopIteration handling is unchanged — `e.value` is still the path.

  ---
  How PM / QA can test

```bash
cd BE
uv run pytest          # should print: 44 passed
```

  To manually inspect the yield output:

```python
from maze import Maze
from backend import get_Astar_result

maze = Maze("#######\n#H.*.*#\n#######\n")
gen  = get_Astar_result(maze)

step = next(gen)
print(step)
# {'pos': (1, 1), 'remaining': frozenset({(1, 3), (1, 5)}), 'cost': {'g': 0, 'h': 4}, 'pq_top': (...)}
```

  Checks:
  - step is a dict with keys `pos`, `remaining`, `cost`, `pq_top`
  - `cost["h"]` is 0 on the last yielded step (terminal state)
  - `len(step["pq_top"]) <= 5`
  - `StopIteration.value` is a non-empty list ending at a * position

  ---

  Notes

  - `MAX_OBJECTIVES = 3` means mazes with 4+ objectives (`*`) now raise ValueError("objective limit") — FE board already caps at 3 snacks so this is a no-op in practice.
  - Board-size validation (8×8 enforcement) is intentionally left to `FE/backend_adapter.py`.