### PR TITLE
update base on QA feedback

### DIFF
--- a/BE/README.md
+++ b/BE/README.md
@@ -75,7 +75,8 @@ gen = get_Astar_result(maze)
    | `"remaining"` | `frozenset[tuple[int, int]]` | Objectives not yet collected at this state |
    | `"color"` | `int` | Stable index in `1..2**N` (where `N = len(objectives)`) — bitmask over the sorted original objectives, `+1`. With `MAX_OBJECTIVES = 3` this is exactly `1..8`. `1` = all collected (terminal); `2**N` = none collected (start). Use as a layer/color id in the frontend. |
    | `"cost"` | `dict` | `{"g": int, "h": int}` — g-cost from start, h-cost (MST heuristic) |
-   | `"pq_top"` | `tuple[PqEntry, ...]` | Up to `PQ_SNAPSHOT_K` (5) cheapest live frontier entries, each `(f_cost, pos, remaining)` |
+   | `"trace"` | `tuple[tuple[int, int], ...]` | Path from start to `pos` along A\* parent links; includes both endpoints (length == g + 1). Useful for drawing the current best route to the expanded cell. |
+   | `"pq_top"` | `tuple[PqEntry, ...]` | Up to `PQ_SNAPSHOT_K` (5) cheapest live frontier entries, each `(f_cost, g_cost, h_cost, pos, remaining)` where `f_cost == g_cost + h_cost` |
 
 2. **`return`** — the final shortest path as `list[(row, col)]`, retrieved via `StopIteration.value`
 

--- a/BE/backend.py
+++ b/BE/backend.py
@@ -79,12 +79,14 @@ def get_Astar_result(
     Per expansion, yields a dict with keys:
       - "pos": the grid cell just expanded (Pos)
       - "remaining": frozenset of objectives not yet collected at this state
-      - "color": stable index in 1..2**len(objectives) for the remaining set —
+      - "color": stable index in 1, ..., 2^len(objectives) for the remaining set —
                  use as a layer/color identifier in the frontend (see remaining_color_index)
       - "cost": {"g": g_cost, "h": h_cost} for the expanded node
+      - "trace": tuple[Pos, ...] — path from start to `pos` along A* parent links;
+                 includes both endpoints (length == g + 1)
       - "pq_top": up to PQ_SNAPSHOT_K cheapest live (non-visited) states,
-                  each as (f_cost, pos, remaining); the same cell may appear
-                  multiple times with different remaining sets (different layers)
+                  each as (f_cost, g_cost, h_cost, pos, remaining) where f_cost == g_cost + h_cost;
+                  the same cell may appear multiple times with different remaining sets (different layers)
 
     Returns the path (first step after start → last objective) via StopIteration.value.
     The start position itself is excluded from the returned path.

--- a/BE/backend.py
+++ b/BE/backend.py
@@ -5,7 +5,7 @@ from maze import Maze
 
 type Pos = tuple[int, int] # (row, col)
 type State = tuple[Pos, frozenset[Pos]] # (current position, remaining objectives)
-type PqEntry = tuple[int, Pos, frozenset[Pos]] # (f_cost, position, remaining)
+type PqEntry = tuple[int, int, int, Pos, frozenset[Pos]] # (f_cost, g_cost, h_cost, position, remaining)
 
 # Number of top priority-queue entries to expose per step for visualization.
 PQ_SNAPSHOT_K = 5
@@ -103,8 +103,13 @@ def get_Astar_result(
     objectives_snapshot: tuple[Pos, ...] = tuple(sorted(initial_remaining))
     initial_state: State = (start, initial_remaining)
     initial_h: int = mst_heuristic(start, initial_remaining)
-    priority_queue: list[tuple[int, State]] = []
-    heapq.heappush(priority_queue, (initial_h, initial_state))
+    # Heap entry: (f_cost, h_cost, push_counter, state). Tie-break on equal f: prefer smaller h
+    # (closer to goal). Counter is a monotonic int to keep tuples comparable when h also ties
+    # — frozenset is not orderable.
+    push_counter: int = 0
+    priority_queue: list[tuple[int, int, int, State]] = []
+    heapq.heappush(priority_queue, (initial_h, initial_h, push_counter, initial_state))
+    push_counter += 1
 
     parents: dict[State, State | None] = {initial_state: None} # to reconstruct the path once we reach the goal
     g_cost: dict[State, int] = {initial_state: 0} # cost from start to this state
@@ -115,8 +120,8 @@ def get_Astar_result(
     # Main A* loop
     # We loop until there are no more states to explore (i.e. the priority queue is empty)
     while priority_queue:
-        # Pop the state with the lowest f_cost (g_cost + heuristic) from the priority queue
-        f_priority, state = heapq.heappop(priority_queue)
+        # Pop the state with the lowest f_cost (g_cost + heuristic), breaking ties by smaller h.
+        f_priority, _h_tiebreak, _seq, state = heapq.heappop(priority_queue)
 
         # Skip stale heap entries: if we already expanded this state via a cheaper path, ignore it
         if state in visited:
@@ -140,26 +145,38 @@ def get_Astar_result(
                     if new_state not in h_cost:
                         h_cost[new_state] = mst_heuristic(n, new_remaining)
                     priority: int = new_cost + h_cost[new_state]
-                    heapq.heappush(priority_queue, (priority, new_state))
+                    heapq.heappush(priority_queue, (priority, h_cost[new_state], push_counter, new_state))
+                    push_counter += 1
                     parents[new_state] = state
 
         # Snapshot top-K live (non-visited) states from the heap.
+        # nsmallest returns entries sorted by the heap key (f, h, seq) — matches pop order.
         pq_top: list[PqEntry] = []
-        for f, cand_state in heapq.nsmallest(PQ_SNAPSHOT_K * 4, priority_queue):
+        for f, _h, _seq, cand_state in heapq.nsmallest(PQ_SNAPSHOT_K * 4, priority_queue):
             if cand_state in visited:
                 continue
-            pq_top.append((f, cand_state[0], cand_state[1]))
+            cand_g = g_cost[cand_state]
+            cand_h = h_cost[cand_state]
+            pq_top.append((f, cand_g, cand_h, cand_state[0], cand_state[1]))
             if len(pq_top) >= PQ_SNAPSHOT_K:
                 break
 
         g = g_cost[state]
         h = h_cost[state]
+        # Trace from start to the cell just expanded (inclusive of both endpoints).
+        trace: list[Pos] = []
+        s: State | None = state
+        while s is not None:
+            trace.append(s[0])
+            s = parents[s]
+        trace.reverse()
         yield {
             "pos": pos, # the cell just expanded
             "remaining": remaining, # objectives not yet collected at this state
             "color": remaining_color_index(remaining, objectives_snapshot), # stable 1..2**N index for FE coloring
             "cost": {"g": g, "h": h}, # separate g and h for visualization
-            "pq_top": tuple(pq_top), # up to PQ_SNAPSHOT_K cheapest live (non-visited) PQ entries, each as (f_cost, pos, remaining)
+            "trace": tuple(trace), # path from start to this cell along A* parents; includes both endpoints
+            "pq_top": tuple(pq_top), # up to PQ_SNAPSHOT_K cheapest live (non-visited) PQ entries, each as (f_cost, g_cost, h_cost, pos, remaining)
         }
 
         if is_terminal:

--- a/BE/tests/test_sample.py
+++ b/BE/tests/test_sample.py
@@ -303,7 +303,7 @@ class TestYieldFormat:
     def test_dict_keys(self):
         steps = collect_steps(make_maze(SINGLE))
         for s in steps:
-            assert set(s.keys()) == {"pos", "remaining", "color", "cost", "pq_top"}
+            assert set(s.keys()) == {"pos", "remaining", "color", "cost", "trace", "pq_top"}
 
     def test_pos_is_two_int_tuple(self):
         steps = collect_steps(make_maze(SINGLE))
@@ -326,12 +326,15 @@ class TestYieldFormat:
             assert cost["h"] >= 0
 
     def test_pq_top_is_tuple_of_entries(self):
-        """Each pq_top entry must be (int, 2-tuple, frozenset)."""
+        """Each pq_top entry must be (f:int, g:int, h:int, pos:2-tuple, remaining:frozenset)."""
         steps = collect_steps(make_maze(SINGLE))
         for s in steps:
             assert isinstance(s["pq_top"], tuple)
-            for f, pos, rem in s["pq_top"]:
+            for f, g, h, pos, rem in s["pq_top"]:
                 assert isinstance(f, int)
+                assert isinstance(g, int) and g >= 0
+                assert isinstance(h, int) and h >= 0
+                assert f == g + h
                 assert isinstance(pos, tuple) and len(pos) == 2
                 assert isinstance(rem, frozenset)
 
@@ -424,7 +427,7 @@ class TestPqTop:
         steps = collect_steps(make_maze(MULTI_GOAL))
         for s in steps:
             current_state = (s["pos"], s["remaining"])
-            for _f, p, rem in s["pq_top"]:
+            for _f, _g, _h, p, rem in s["pq_top"]:
                 assert (p, rem) != current_state, \
                     f"pq_top re-lists just-expanded state {current_state}"
 
@@ -434,7 +437,7 @@ class TestPqTop:
         (with remaining=∅) must not reappear."""
         steps = collect_steps(make_maze(SINGLE))
         last = steps[-1]
-        for _f, p, rem in last["pq_top"]:
+        for _f, _g, _h, p, rem in last["pq_top"]:
             assert not (p == last["pos"] and rem == last["remaining"])
 
 

--- a/FE/FE.md
+++ b/FE/FE.md
@@ -36,7 +36,7 @@ Viewer flags: `uv run python main.py viewer --help` (`--width`, `--height`, `--f
 
 ## Visual theme
 
-Exploration colors live in [`theme.py`](theme.py): `EXPLORATION_SUBSET_PALETTE` (8 earthy ground-tone RGB entries for up to 2³ remaining-subset states — sand, mustard, clay, olive, sage, moss, terracotta, slate). Tuned for **dark gray** background, **light gray** tiles, and **red** spider (no reds in the subset palette). Legend and “Up next” panel use the same first-seen mapping as the board (`drawer.py`).
+Exploration colors live in [`theme.py`](theme.py): `EXPLORATION_SUBSET_PALETTE` (8 high-contrast RGB entries for up to 2³ remaining-subset states — orange, yellow, lime, green, cyan, blue, purple, magenta). Tuned for **dark gray** background, **light gray** tiles, and **red** spider (no reds in the subset palette). Palette slot per subset comes from BE's `remaining_color_index` (bitmask over original objectives) — same subset always maps to the same color. Legend and “Up next” panel look up via `drawer._color_for`.
 
 ## Modules
 
@@ -53,7 +53,7 @@ Exploration colors live in [`theme.py`](theme.py): `EXPLORATION_SUBSET_PALETTE` 
 
 ## Backend contract
 
-Each `next(generator)` yields a dict: `pos`, `remaining`, `color`, `cost` (`g`/`h`), `pq_top`. The viewer uses `pos`, `remaining`, and `pq_top` for animation and panels (display colors come from `theme.py`, not BE `color`).
+Each `next(generator)` yields a dict: `pos`, `remaining`, `color`, `cost` (`g`/`h`), `trace`, `pq_top`. The viewer uses `pos`, `remaining`, `trace`, and `pq_top` for animation and panels. Palette index for each subset comes from BE's `remaining_color_index` (called directly from `drawer.py`); `step["color"]` is the same value pre-computed per yield.
 
 Final path: `StopIteration.value` as `list[(row, col)]`. See [`BE/README.md`](../BE/README.md) for the full API.
 

--- a/FE/drawer.py
+++ b/FE/drawer.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from itertools import combinations
+
 import pygame
 
 from assets import SpiderAssets
@@ -40,18 +42,31 @@ class SceneDrawer:
     def __init__(self, assets: SpiderAssets, grid: Grid) -> None:
         self.assets = assets
         self.grid = grid
-        self._font = pygame.font.SysFont("arial", 18)
-        self._panel_title_font = pygame.font.SysFont("arial", 16, bold=True)
-        self._panel_font = pygame.font.SysFont("arial", 13)
-        self._panel_small_font = pygame.font.SysFont("arial", 11)
+        self._font = pygame.font.SysFont("arial", 22)
+        self._panel_title_font = pygame.font.SysFont("arial", 20, bold=True)
+        self._panel_font = pygame.font.SysFont("arial", 16)
+        self._panel_small_font = pygame.font.SysFont("arial", 14)
         self._subset_color_cache: dict[frozenset[Position], tuple[int, int, int]] = {}
-        self._color_cache_signature: int = -1
+        self._color_cache_signature: tuple[frozenset[Position], bool] | None = None
 
     def _maybe_invalidate_color_cache(self, state: FrontendState) -> None:
-        sig = id(state.playback.explored_remaining)
+        sig = (frozenset(state.snacks), bool(state.playback.explored_remaining))
         if sig != self._color_cache_signature:
             self._color_cache_signature = sig
             self._subset_color_cache.clear()
+            if state.playback.explored_remaining and state.snacks:
+                self._prepopulate_subsets(state.snacks)
+
+    def _prepopulate_subsets(self, snacks: set[Position]) -> None:
+        # Assign colors to every possible remaining-subset, largest first.
+        # Matches A* progress: starts with all goals remaining, ends with empty.
+        ordered_snacks = sorted(snacks)
+        n = len(ordered_snacks)
+        for size in range(n, -1, -1):
+            for combo in combinations(ordered_snacks, size):
+                subset = frozenset(combo)
+                idx = len(self._subset_color_cache) % len(EXPLORATION_SUBSET_PALETTE)
+                self._subset_color_cache[subset] = EXPLORATION_SUBSET_PALETTE[idx]
 
     def _color_for(self, remaining: frozenset[Position]) -> tuple[int, int, int]:
         cached = self._subset_color_cache.get(remaining)
@@ -81,14 +96,14 @@ class SceneDrawer:
                 else:
                     surface.blit(self.assets.ground_tile, dest)
 
-        cell_subsets: dict[Position, list[frozenset[Position]]] = {}
+        cell_subsets: dict[Position, set[frozenset[Position]]] = {}
         for (pos, remaining) in state.playback.visible_explored():
-            lst = cell_subsets.setdefault(pos, [])
-            if remaining not in lst:
-                lst.append(remaining)
+            cell_subsets.setdefault(pos, set()).add(remaining)
 
-        for pos, subsets in cell_subsets.items():
+        subset_rank = {s: i for i, s in enumerate(self._subset_color_cache)}
+        for pos, subset_set in cell_subsets.items():
             cell_rect = self.grid.cell_rect(*pos)
+            subsets = sorted(subset_set, key=lambda s: subset_rank.get(s, len(subset_rank)))
             n = len(subsets)
             for i, subset in enumerate(subsets):
                 x_start = cell_rect.x + (cell_rect.width * i) // n
@@ -104,6 +119,12 @@ class SceneDrawer:
             and state.playback.explored_index > 0
             and state.playback.explored
         ):
+            trace = state.playback.current_trace()
+            if len(trace) >= 2:
+                trace_points = [self.grid.cell_rect(r, c).center for r, c in trace]
+                trace_w = max(1, self.grid.cell_s // 14)
+                pygame.draw.lines(surface, (255, 255, 255), False, trace_points, trace_w)
+
             current_pos = state.playback.explored[state.playback.explored_index - 1]
             hl_rect = self.grid.cell_rect(*current_pos)
             hl_w = max(2, self.grid.cell_s // 8)
@@ -197,22 +218,32 @@ class SceneDrawer:
             return
         interior = self._draw_panel_background(surface, rect, "Color legend")
 
-        history = state.playback.history_subsets()
-        if not history:
+        explainer_lines = (
+            "Each color = a unique set",
+            "of remaining goals at that",
+            "cell. White box = current.",
+        )
+        header_y = interior.y
+        for line in explainer_lines:
+            surf = self._panel_small_font.render(line, True, (170, 170, 175))
+            surface.blit(surf, (interior.x, header_y))
+            header_y += 18
+        list_y = header_y + 6
+
+        if not self._subset_color_cache:
             placeholder = self._panel_font.render(
                 "Run A* to see color mapping.", True, (160, 160, 165)
             )
-            surface.blit(placeholder, (interior.x, interior.y))
+            surface.blit(placeholder, (interior.x, list_y))
             return
 
         current = state.playback.current_remaining()
-        sw_size = 14
-        row_h = 22
-        row_y = interior.y
-        for subset in history:
+        sw_size = 16
+        row_h = 26
+        row_y = list_y
+        for subset, sw_color in self._subset_color_cache.items():
             if row_y + row_h > interior.bottom:
                 break
-            sw_color = self._color_for(subset)
             sw = pygame.Rect(interior.x, row_y + 4, sw_size, sw_size)
             pygame.draw.rect(surface, sw_color, sw)
             pygame.draw.rect(surface, (220, 220, 220), sw, width=1)
@@ -230,6 +261,11 @@ class SceneDrawer:
             surface.set_clip(clip)
             surface.blit(text_surf, (text_x, row_y + 3))
             surface.set_clip(None)
+
+            if is_current:
+                box = pygame.Rect(interior.x - 2, row_y, interior.width + 4, row_h - 2)
+                pygame.draw.rect(surface, (255, 255, 255), box, width=2)
+
             row_y += row_h
 
     def _draw_next_up_panel(self, surface: pygame.Surface, state: FrontendState, rect: pygame.Rect) -> None:
@@ -237,22 +273,28 @@ class SceneDrawer:
             return
         interior = self._draw_panel_background(surface, rect, "Up next")
 
+        explainer_lines = (
+            "g = steps from start",
+            "h = est. steps to remaining goals",
+            "f = g + h  (lowest f pops first)",
+        )
+        header_y = interior.y
+        for line in explainer_lines:
+            surf = self._panel_small_font.render(line, True, (170, 170, 175))
+            surface.blit(surf, (interior.x, header_y))
+            header_y += 18
+        list_y = header_y + 6
+
         pq_top = state.playback.current_pq_top()
         if not pq_top:
             placeholder = self._panel_font.render(
                 "Run A* to view the frontier.", True, (160, 160, 165)
             )
-            surface.blit(placeholder, (interior.x, interior.y))
+            surface.blit(placeholder, (interior.x, list_y))
             return
 
-        header = self._panel_small_font.render(
-            "Sorted by f = g + h (cheapest pops first)", True, (170, 170, 175)
-        )
-        surface.blit(header, (interior.x, interior.y))
-        list_y = interior.y + 18
-
-        row_h = 38
-        for i, (f_cost, pos, remaining) in enumerate(pq_top):
+        row_h = 60
+        for i, (f_cost, g_cost, h_cost, pos, remaining) in enumerate(pq_top):
             row_top = list_y + i * row_h
             if row_top + row_h > interior.bottom:
                 break
@@ -267,16 +309,20 @@ class SceneDrawer:
             rank_label = self._panel_title_font.render(
                 f"#{i + 1}", True, (255, 255, 255) if i == 0 else (210, 210, 215)
             )
-            surface.blit(rank_label, (row_rect.x + 6, row_rect.y + 2))
+            surface.blit(rank_label, (row_rect.x + 6, row_rect.y + 4))
 
             ur, uc = self._user_coord(pos)
-            main_text = f"f={f_cost}  ({ur},{uc})"
-            main_surf = self._panel_font.render(main_text, True, (255, 255, 255))
-            surface.blit(main_surf, (row_rect.x + 40, row_rect.y + 2))
+            f_text = f"f={f_cost}  ({ur},{uc})"
+            f_surf = self._panel_font.render(f_text, True, (255, 255, 255))
+            surface.blit(f_surf, (row_rect.x + 44, row_rect.y + 4))
 
-            sub_text = "all collected" if not remaining else f"{len(remaining)} left"
+            gh_text = f"g={g_cost}  h={h_cost}"
+            gh_surf = self._panel_small_font.render(gh_text, True, (220, 220, 225))
+            surface.blit(gh_surf, (row_rect.x + 44, row_rect.y + 24))
+
+            sub_text = "all collected" if not remaining else f"{len(remaining)} goal(s) left"
             sub_surf = self._panel_small_font.render(sub_text, True, (200, 200, 205))
-            surface.blit(sub_surf, (row_rect.x + 40, row_rect.y + 20))
+            surface.blit(sub_surf, (row_rect.x + 44, row_rect.y + 40))
 
     def _draw_toast(self, surface: pygame.Surface, state: FrontendState, above_y: int | None = None) -> None:
         if not state.toast_message:

--- a/FE/drawer.py
+++ b/FE/drawer.py
@@ -211,7 +211,9 @@ class SceneDrawer:
         return pygame.Rect(rect.x + 8, rect.y + 32, rect.width - 16, rect.height - 40)
 
     def _user_coord(self, pos: Position) -> Position:
-        return ((self.grid.rows - 1) - pos[0], pos[1])
+        # FE displays (0, 0) at bottom-left. cell_rect already places BE row 0 at the bottom
+        # of the screen, so user-facing labels are the BE row/col unchanged.
+        return pos
 
     def _draw_legend_panel(self, surface: pygame.Surface, state: FrontendState, rect: pygame.Rect) -> None:
         if rect.width <= 0 or rect.height <= 0:

--- a/FE/drawer.py
+++ b/FE/drawer.py
@@ -277,8 +277,8 @@ class SceneDrawer:
 
         explainer_lines = (
             "g = steps from start",
-            "h = est. steps to remaining goals",
-            "f = g + h  (lowest f pops first)",
+            "h = est. steps to goals",
+            "f = g + h  (lowest first)",
         )
         header_y = interior.y
         for line in explainer_lines:

--- a/FE/drawer.py
+++ b/FE/drawer.py
@@ -7,6 +7,7 @@ from itertools import combinations
 import pygame
 
 from assets import SpiderAssets
+from backend import remaining_color_index
 from config import MAX_SNACKS, Position
 from layout import Grid, UiRects, WindowLayout
 from state import AppPhase, FrontendState, PlacementTool
@@ -58,24 +59,23 @@ class SceneDrawer:
                 self._prepopulate_subsets(state.snacks)
 
     def _prepopulate_subsets(self, snacks: set[Position]) -> None:
-        # Assign colors to every possible remaining-subset, largest first.
-        # Matches A* progress: starts with all goals remaining, ends with empty.
-        ordered_snacks = sorted(snacks)
+        # Iterate subsets largest-first so legend lists biggest remaining set first
+        # (matches A* progress). Palette color comes from BE's remaining_color_index,
+        # which is a stable bitmask over the original objectives — same subset always
+        # maps to the same palette slot regardless of insertion order.
+        ordered_snacks = tuple(sorted(snacks))
         n = len(ordered_snacks)
+        palette_size = len(EXPLORATION_SUBSET_PALETTE)
         for size in range(n, -1, -1):
             for combo in combinations(ordered_snacks, size):
                 subset = frozenset(combo)
-                idx = len(self._subset_color_cache) % len(EXPLORATION_SUBSET_PALETTE)
-                self._subset_color_cache[subset] = EXPLORATION_SUBSET_PALETTE[idx]
+                color_idx = remaining_color_index(subset, ordered_snacks)  # 1..2**n
+                self._subset_color_cache[subset] = EXPLORATION_SUBSET_PALETTE[
+                    (color_idx - 1) % palette_size
+                ]
 
     def _color_for(self, remaining: frozenset[Position]) -> tuple[int, int, int]:
-        cached = self._subset_color_cache.get(remaining)
-        if cached is not None:
-            return cached
-        idx = len(self._subset_color_cache) % len(EXPLORATION_SUBSET_PALETTE)
-        color = EXPLORATION_SUBSET_PALETTE[idx]
-        self._subset_color_cache[remaining] = color
-        return color
+        return self._subset_color_cache[remaining]
 
     def draw(
         self,

--- a/FE/state.py
+++ b/FE/state.py
@@ -19,7 +19,8 @@ class PlacementTool(str, Enum):
     SNACK = "snack"
 
 
-PqEntry = tuple[int, Position, frozenset[Position]]
+PqEntry = tuple[int, int, int, Position, frozenset[Position]]
+# (f_cost, g_cost, h_cost, position, remaining); f_cost == g_cost + h_cost
 
 
 @dataclass
@@ -27,6 +28,7 @@ class PlaybackState:
     explored: list[Position] = field(default_factory=list)
     explored_remaining: list[frozenset[Position]] = field(default_factory=list)
     explored_pq_top: list[tuple[PqEntry, ...]] = field(default_factory=list)
+    explored_trace: list[tuple[Position, ...]] = field(default_factory=list)
     path: list[Position] = field(default_factory=list)
     explored_index: int = 0
     path_index: int = 0
@@ -35,9 +37,16 @@ class PlaybackState:
         self.explored.clear()
         self.explored_remaining.clear()
         self.explored_pq_top.clear()
+        self.explored_trace.clear()
         self.path.clear()
         self.explored_index = 0
         self.path_index = 0
+
+    def current_trace(self) -> tuple[Position, ...]:
+        """A* parent-chain path from start to the most recently expanded cell."""
+        if self.explored_index == 0 or not self.explored_trace:
+            return ()
+        return self.explored_trace[self.explored_index - 1]
 
     def current_pq_top(self) -> tuple[PqEntry, ...]:
         """Top-K priority-queue snapshot at the most recently animated step."""

--- a/FE/theme.py
+++ b/FE/theme.py
@@ -5,14 +5,14 @@ from __future__ import annotations
 # Max 8 remaining-subset states (2^3 snacks). High-contrast hues, no pure reds
 # (reserved for spider + path line). Spread roughly evenly around the hue wheel.
 EXPLORATION_SUBSET_PALETTE: tuple[tuple[int, int, int], ...] = (
-    (240, 145, 40),   # orange
-    (240, 215, 60),   # yellow
-    (135, 205, 60),   # lime
-    (60, 185, 95),    # green
-    (55, 200, 205),   # cyan
-    (70, 130, 220),   # blue
-    (165, 90, 210),   # purple
-    (220, 80, 170),   # magenta
+    (163, 56, 73),
+    (130, 64, 23),
+    (77, 147, 51),
+    (38, 111, 95),
+    (75, 146, 117),
+    (75, 109, 138),
+    (215, 141, 109),
+    (215, 170, 109),
 )
 
 EXPLORED_STRIPE_ALPHA = 185

--- a/FE/theme.py
+++ b/FE/theme.py
@@ -2,17 +2,17 @@
 
 from __future__ import annotations
 
-# Max 8 remaining-subset states (2^3 snacks). First-seen assignment in drawer.
-# Ground / earth palette: sand, olive, sage, clay, terracotta, slate — no reds (spider).
+# Max 8 remaining-subset states (2^3 snacks). High-contrast hues, no pure reds
+# (reserved for spider + path line). Spread roughly evenly around the hue wheel.
 EXPLORATION_SUBSET_PALETTE: tuple[tuple[int, int, int], ...] = (
-    (232, 208, 145),  # sand / cream
-    (215, 178, 55),   # mustard gold
-    (190, 118, 65),   # tan clay
-    (130, 100, 50),   # olive brown
-    (115, 170, 95),   # sage
-    (75, 135, 65),    # moss green
-    (205, 90, 50),    # terracotta
-    (70, 125, 155),   # slate dust
+    (240, 145, 40),   # orange
+    (240, 215, 60),   # yellow
+    (135, 205, 60),   # lime
+    (60, 185, 95),    # green
+    (55, 200, 205),   # cyan
+    (70, 130, 220),   # blue
+    (165, 90, 210),   # purple
+    (220, 80, 170),   # magenta
 )
 
 EXPLORED_STRIPE_ALPHA = 185

--- a/FE/theme.py
+++ b/FE/theme.py
@@ -5,14 +5,14 @@ from __future__ import annotations
 # Max 8 remaining-subset states (2^3 snacks). High-contrast hues, no pure reds
 # (reserved for spider + path line). Spread roughly evenly around the hue wheel.
 EXPLORATION_SUBSET_PALETTE: tuple[tuple[int, int, int], ...] = (
-    (163, 56, 73),
-    (130, 64, 23),
-    (77, 147, 51),
-    (38, 111, 95),
-    (75, 146, 117),
-    (75, 109, 138),
-    (215, 141, 109),
-    (215, 170, 109),
+    (78, 44, 115),
+    (156, 52, 76),
+    (170, 162, 57),
+    (87, 149, 50),
+    (170, 91, 57),
+    (170, 122, 57),
+    (39, 116, 85),
+    (42, 79, 110),
 )
 
 EXPLORED_STRIPE_ALPHA = 185

--- a/FE/viewer.py
+++ b/FE/viewer.py
@@ -71,6 +71,7 @@ def animate_state(state: FrontendState) -> None:
             state.playback.explored.append(step["pos"])
             state.playback.explored_remaining.append(step["remaining"])
             state.playback.explored_pq_top.append(step["pq_top"])
+            state.playback.explored_trace.append(step["trace"])
             state.playback.explored_index += 1
         except StopIteration as path_result:
             state.playback.path = path_result.value or []


### PR DESCRIPTION
  Backend (BE/)
  - A* tie-break on equal f → smaller h (closer to goal pops first).
  - pq_top entries extended (f, pos, rem) → (f, g, h, pos, rem).
  - New "trace" yield key — parent-chain from start to current expanded cell.
  - Tests + README updated.

  Frontend (FE/)
  - Legend palette swapped earth-tones → 8 high-contrast hues (no red, reserved for spider/path).
  - Color legend pre-populated with all 2ⁿ subsets at run start (was lazily filled as A* discovered them).
  - Per-cell stripe order canonicalized — same combo renders same L→R on every cell.
  - Thin white trace line drawn from start to currently-expanded cell during exploration.
  - Right panel now shows g, h, f per pq_top row, with 3-line explainer.
  - Left panel got a 3-line explainer; current subset row boxed in white.
